### PR TITLE
add celery system_health_check task, configure queue/routing and sche…

### DIFF
--- a/src/maiagent/config/settings/base.py
+++ b/src/maiagent/config/settings/base.py
@@ -314,6 +314,27 @@ CELERY_WORKER_SEND_TASK_EVENTS = True
 CELERY_TASK_SEND_SENT_EVENT = True
 # https://docs.celeryq.dev/en/stable/userguide/configuration.html#worker-hijack-root-logger
 CELERY_WORKER_HIJACK_ROOT_LOGGER = False
+CELERY_TASK_DEFAULT_QUEUE = "default"
+CELERY_TASK_QUEUES = {
+    "default": {},
+    "ai_queue": {},
+    "monitor_queue": {},
+}
+CELERY_TASK_ROUTES = {
+    # AI 訊息處理任務走高優先級佇列
+    "maiagent.chat.tasks.process_message": {"queue": "ai_queue", "routing_key": "ai.process"},
+    # 系統監控任務
+    "maiagent.chat.tasks.system_health_check": {"queue": "monitor_queue", "routing_key": "monitor.health"},
+}
+
+# Celery Beat 排程（以資料庫排程器為主，提供預設值便於本地快速啟用）
+CELERY_BEAT_SCHEDULE = {
+    "system-health-check-5m": {
+        "task": "maiagent.chat.tasks.system_health_check",
+        "schedule": 5 * 60,
+        "options": {"queue": "monitor_queue", "routing_key": "monitor.health"},
+    }
+}
 
 # django-allauth
 # ------------------------------------------------------------------------------

--- a/src/maiagent/maiagent/chat/tasks.py
+++ b/src/maiagent/maiagent/chat/tasks.py
@@ -1,8 +1,13 @@
 from __future__ import annotations
 
 from datetime import datetime
+import logging
+import ssl
 
 from celery import shared_task
+from django.conf import settings
+from django.db import connection
+from redis import Redis
 
 from .models import Message, Session
 
@@ -21,3 +26,35 @@ def process_message(self, session_id: str, user_message_id: str) -> None:
     session.save(update_fields=["status", "last_activity_at"])
 
 
+@shared_task(bind=True, name="maiagent.chat.tasks.system_health_check", max_retries=0)
+def system_health_check(self) -> dict:
+    """簡易系統健康檢查：資料庫與 Redis broker。
+
+    返回各服務狀態，僅做基本可用性檢查。
+    """
+    logger = logging.getLogger(__name__)
+    results: dict = {"database": "unknown", "redis_broker": "unknown"}
+
+    # Database health check
+    try:
+        with connection.cursor() as cursor:
+            cursor.execute("SELECT 1")
+            cursor.fetchone()
+        results["database"] = "ok"
+    except Exception as exc:  # noqa: BLE001
+        results["database"] = f"error: {exc}"
+        logger.exception("Database health check failed")
+
+    # Redis (broker) health check
+    try:
+        if getattr(settings, "REDIS_SSL", False):
+            client = Redis.from_url(settings.REDIS_URL, ssl_cert_reqs=ssl.CERT_NONE)
+        else:
+            client = Redis.from_url(settings.REDIS_URL)
+        client.ping()
+        results["redis_broker"] = "ok"
+    except Exception as exc:  # noqa: BLE001
+        results["redis_broker"] = f"error: {exc}"
+        logger.exception("Redis health check failed")
+
+    return results


### PR DESCRIPTION
- 新增 maiagent.chat.tasks.system_health_check：檢查資料庫與 Redis（含 TLS rediss 支援），回傳簡易狀態並記錄日誌
- 保留並確認 process_message 行為，維持簡易自動回覆並更新 Session 狀態為 Replyed
- 設定 Celery 佇列與路由：
  - process_message → ai_queue（routing_key: ai.process）
  - system_health_check → monitor_queue（routing_key: monitor.health）
- 新增 Celery Beat 預設排程：每 5 分鐘執行 system_health_check（使用 django-celery-beat）